### PR TITLE
Semigroup/Monoid compatibility for GHC from 8.0.2 to 8.6.2

### DIFF
--- a/semiring-num.cabal
+++ b/semiring-num.cabal
@@ -1,5 +1,5 @@
 name:                semiring-num
-version:             1.6.0.1
+version:             1.6.0.2
 synopsis:            Basic semiring class and instances
 description:         Adds a basic semiring class
 homepage:            https://github.com/oisdk/semiring-num

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,14 @@
-resolver: lts-9.6
+# resolver: lts-9.6 # ghc-8.0.2
+
+# resolver: lts-9.20  # ghc-8.0.2
+# resolver: lts-11.12 # ghc-8.2.2
+# resolver: lts-12.4  # ghc-8.4.3
+resolver: lts-12.19 # ghc-8.4.4
+
+# resolver: nightly-2018-11-23 # ghc-8.6.2
+
+# "stack build" succeeds (warning-free) with all of the resolvers above.
+
 packages:
 - '.'
 extra-deps:


### PR DESCRIPTION
Tweaked for `Semigroup`/`Monoid` compatibility for GHC from 8.0.2 to 8.6.2, following [a guide for compatible code](https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid#Writingcompatiblecode). I've tested with Stack resolvers for GHC versions 8.0.2, 8.2.2, 8.4.3, 8.4.4, and 8.6.2 (as in the altered stack.yaml).
